### PR TITLE
Batch mmseq : Support YAML & FASTA Inputs for Boltz MSA

### DIFF
--- a/subworkflows/local/msa.nf
+++ b/subworkflows/local/msa.nf
@@ -22,7 +22,7 @@ workflow MSA {
     ch_samplesheet
     .branch {
         fasta: it[1].extension == "fasta" || it[1].extension == "fa"
-        yaml: it[1].extension == "yaml"
+        yaml: it[1].extension == "yaml" || it[1].extension == ".yml"
         json: it[1].extension == "json"
     }
     .set{ch_input}
@@ -33,16 +33,29 @@ workflow MSA {
         meta.cnt = getFastaSequences(it[1].text).size();
         [meta, it[1]]
     }
-    .set{ch_input_full}
+    .set{ch_input_fasta}
+
+    ch_input.yaml
+    .map {
+        meta = it[0].clone();
+        meta.cnt = getYamlSequences(it[1].text).size();
+        [meta, it[1]]
+    }
+    .set { ch_input_yaml }
+
+    ch_input_full = ch_input_fasta.mix(ch_input_yaml)
 
     if (true){
         def batch_itr = 0
         ch_input_full
         .map{it[1]}
         .unique()
-        .map{"${it.baseName},${getFastaSequences(it.text)
-                .collect { it.sequence }
-                .join(':')}"
+        .map {
+            def sequences = it.name.endsWith(".yaml") || it.name.endsWith(".yml")
+                ? getYamlSequences(it.text)
+                : getFastaSequences(it.text)
+
+            "${it.baseName},${sequences.collect { it.sequence }.join(':')}"
         }
         .buffer( size: mmseq_batch_size, remainder: true )
         .collectFile {
@@ -106,7 +119,7 @@ def getYamlSequences(yamlData) {
 
         if (trimmed.startsWith('-') && trimmed.endsWith(':')) {
             if (!currentEntry.isEmpty()) {
-                sequences << currentEntry
+                enrichedEntries << currentEntry
             }
             currentEntry = ['type': trimmed[1..-2]]
         }else{
@@ -115,7 +128,7 @@ def getYamlSequences(yamlData) {
         }
     }
     if (!currentEntry.isEmpty()) {
-        sequences << currentEntry
+        enrichedEntries << currentEntry
     }
     return enrichedEntries
 }

--- a/workflows/boltz.nf
+++ b/workflows/boltz.nf
@@ -56,6 +56,13 @@ workflow BOLTZ {
     main:
     ch_multiqc_files = Channel.empty()
 
+    ch_samplesheet
+        .branch {
+            fasta: it[1].extension == "fasta" || it[1].extension == "fa"
+            yaml: it[1].extension == "yaml" || it[1].extension == "yml"
+        }
+        .set { ch_input_by_ext }
+
     if (!msa_server){
         MSA(
             ch_samplesheet,
@@ -96,9 +103,39 @@ workflow BOLTZ {
         ch_prepare_fasta
     )
 
+    // Prepare YAML input with a placeholder for MSA
+    def ch_boltz_input_yaml = ch_input_by_ext.yaml
+        .map { meta, file ->
+            meta.original_file = file
+            [meta, file, []]  // we leave msa as empty array here
+        }
+        .combine(BOLTZ_FASTA.out.formatted_fasta.first(), by: 0) // block until FASTA done
+        .map { yaml_entry, _ -> yaml_entry } // drop the dummy FASTA
+
+    // Now inject MSA back in
+    def ch_boltz_input_yaml_with_msa = ch_boltz_input_yaml
+        .map { meta, file, _ ->
+            def fasta_match = BOLTZ_FASTA.out.formatted_fasta
+                .filter { it[0].id == meta.id } // match by ID
+                .first()
+            fasta_match.map { unused_meta, unused_file, msa -> [meta, meta.original_file ?: file, msa] }
+
+        }
+        .flatten()
+
+    // Final input: YAMLs with MSA + converted FASTAs
+    ch_boltz_input_yaml_with_msa
+        .concat(BOLTZ_FASTA.out.formatted_fasta)
+        .set { ch_boltz_input }
+
+    ch_boltz_input_yaml_with_msa.view { "YAML w/ MSA: $it" }
+    
+    BOLTZ_FASTA.out.formatted_fasta.view { "FASTA: $it" }
+
+
     RUN_BOLTZ(
-        BOLTZ_FASTA.out.formatted_fasta.map{[it[0], it[1]]},
-        BOLTZ_FASTA.out.formatted_fasta.map{it[2]},
+        ch_boltz_input.map{[it[0], it[1]]},
+        ch_boltz_input.map{it[2]},
         ch_boltz_model,
         ch_boltz_ccd
     )

--- a/workflows/boltz.nf
+++ b/workflows/boltz.nf
@@ -78,8 +78,7 @@ workflow BOLTZ {
             monomer: it[0].cnt == 1
         }
         .set{ch_input}
-        MSA.out.formated_input.view()
-        MSA.out.a3m.view()
+
         SPLIT_MSA(
             MSA.out.a3m.filter{it[0].cnt > 1}
         )
@@ -126,19 +125,16 @@ workflow BOLTZ {
         ch_prepare_fasta
     )
 
-    // Index YAML by ID for joining with a placeholder MSA
     def ch_yaml_indexed = ch_input_by_ext.yaml
         .map { meta, file ->
-            [meta.id, [meta, file, []]]  // we leave msa as empty array here
+            [meta.id, [meta, file, []]]
         }
 
 
-    // Index FASTA by ID
     def ch_fasta_indexed = BOLTZ_FASTA.out.formatted_fasta.map { meta, file, msa ->
         [meta.id, [meta, file, msa]]
     }
 
-    // Join YAML and FASTA on ID
     def ch_boltz_input_yaml_with_msa = ch_yaml_indexed
         .join(ch_fasta_indexed, remainder: true)
         .map { id, yamlEntry, fastaEntry ->
@@ -147,10 +143,6 @@ workflow BOLTZ {
             [yamlMeta, yamlFile, msa]
         }
     .set { ch_boltz_input }
-
-    ch_input_by_ext.yaml.view { "Raw YAML input: $it" }
-    ch_boltz_input.view { "YAML w/ MSA: $it" }
-    BOLTZ_FASTA.out.formatted_fasta.view { "FASTA: $it" }
 
     RUN_BOLTZ(
         ch_boltz_input.map{[it[0], it[1]]},

--- a/workflows/boltz.nf
+++ b/workflows/boltz.nf
@@ -91,11 +91,34 @@ workflow BOLTZ {
             ).set{ch_prepare_fasta}
 
     }else{
+        ch_input_by_ext.fasta
+            .join(
+                ch_input_by_ext.fasta
+                    .map { meta, file ->
+                        [
+                            meta,
+                            file.text.findAll { letter -> letter == ">" }.size()
+                        ]
+                    }
+            )
+
+        .map{
+            def meta = it[0].clone()
+            meta.cnt = it[2]
+            [meta, it[1]]
+        }
+        .branch{
+            multimer: it[0].cnt > 1
+            monomer: it[0].cnt == 1
+        }
+        .set{ch_input}
+
+        ch_input_by_ext.yaml.mix(
         ch_input
         .multimer
         .mix(ch_input
         .monomer
-        ).map{[it[0], it[1], []]}
+        )).map{[it[0], it[1], []]}
         .set{ch_prepare_fasta}
     }
 
@@ -103,35 +126,31 @@ workflow BOLTZ {
         ch_prepare_fasta
     )
 
-    // Prepare YAML input with a placeholder for MSA
-    def ch_boltz_input_yaml = ch_input_by_ext.yaml
+    // Index YAML by ID for joining with a placeholder MSA
+    def ch_yaml_indexed = ch_input_by_ext.yaml
         .map { meta, file ->
-            meta.original_file = file
-            [meta, file, []]  // we leave msa as empty array here
+            [meta.id, [meta, file, []]]  // we leave msa as empty array here
         }
-        .combine(BOLTZ_FASTA.out.formatted_fasta.first(), by: 0) // block until FASTA done
-        .map { yaml_entry, _ -> yaml_entry } // drop the dummy FASTA
 
-    // Now inject MSA back in
-    def ch_boltz_input_yaml_with_msa = ch_boltz_input_yaml
-        .map { meta, file, _ ->
-            def fasta_match = BOLTZ_FASTA.out.formatted_fasta
-                .filter { it[0].id == meta.id } // match by ID
-                .first()
-            fasta_match.map { unused_meta, unused_file, msa -> [meta, meta.original_file ?: file, msa] }
 
+    // Index FASTA by ID
+    def ch_fasta_indexed = BOLTZ_FASTA.out.formatted_fasta.map { meta, file, msa ->
+        [meta.id, [meta, file, msa]]
+    }
+
+    // Join YAML and FASTA on ID
+    def ch_boltz_input_yaml_with_msa = ch_yaml_indexed
+        .join(ch_fasta_indexed, remainder: true)
+        .map { id, yamlEntry, fastaEntry ->
+            def (yamlMeta, yamlFile, unusedMsa) = yamlEntry ?: fastaEntry
+            def (unusedMeta, unusedFile, msa) = fastaEntry
+            [yamlMeta, yamlFile, msa]
         }
-        .flatten()
+    .set { ch_boltz_input }
 
-    // Final input: YAMLs with MSA + converted FASTAs
-    ch_boltz_input_yaml_with_msa
-        .concat(BOLTZ_FASTA.out.formatted_fasta)
-        .set { ch_boltz_input }
-
-    ch_boltz_input_yaml_with_msa.view { "YAML w/ MSA: $it" }
-    
+    ch_input_by_ext.yaml.view { "Raw YAML input: $it" }
+    ch_boltz_input.view { "YAML w/ MSA: $it" }
     BOLTZ_FASTA.out.formatted_fasta.view { "FASTA: $it" }
-
 
     RUN_BOLTZ(
         ch_boltz_input.map{[it[0], it[1]]},


### PR DESCRIPTION
###  Summary of Changes

This PR introduces support for local MSA for YAML-formatted input in addition to FASTA for the `boltz` workflow. Changes were made in both `subworkflows/msa.nf` and `workflows/boltz.nf`.

---
###  Updates

#### 1. `subworkflows/msa.nf`
- Fixed function: `getYamlSequences(yamlData)`
- Updated logic to handle input parsing for YAML and FASTA files.

#### 2. `workflows/boltz.nf`
- Added conditional handling for YAML vs FASTA input.
- Integrates correct MSA paths into the Boltz input tuple for both formats
---
### Caveats for YAML Input Mode

When using YAML input, MSA files must be pre-specified and available **by relative path** within the work directory. These paths should align with how files are named internally during pipeline execution.

#### Monomer YAML Example:

```yaml
sequences:
  - protein:
      id: [A1]
      sequence: MYSEQ...
      msa: <yaml_prefix>.a3m
```
Each `msa:` field should point to a `.a3m` file generated by the `MMSEQS_COLABFOLDSEARCH` module.

#### Multimer YAML Example:
```yaml
sequences:
  - protein:
      id: A
      sequence: MYSEQ...
      msa: A.csv
  - protein:
      id: B
      sequence: MYSEQ...
      msa: B.csv
```

Each `msa:` field should point to a `.csv` generated by the `SPLIT_MSA` module.

---
### Tested:
- Monomer YAML processed with .a3m MSA 
- Multimer YAML processed with .csv MSAs  
- FASTA with standard MSA path

